### PR TITLE
Rack-attack middleware

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -13,7 +13,7 @@ Rails.application.configure do
   config.eager_load = true
 
   # Full error reports are disabled and caching is turned on.
-  config.consider_all_requests_local       = false
+  config.consider_all_requests_local = false
 
   # Ensures that a master key has been made available in either ENV["RAILS_MASTER_KEY"]
   # or in config/master.key. This key is used to decrypt credentials (and other encrypted files).
@@ -39,7 +39,7 @@ Rails.application.configure do
   # config.action_cable.allowed_request_origins = [ 'http://example.com', /http:\/\/example.*/ ]
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  # config.force_ssl = true
+  config.force_ssl = true
 
   # Include generic and useful information about system operation, but avoid logging too much
   # information to avoid inadvertent exposure of personally identifiable information (PII).

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -1,28 +1,32 @@
-class Rack::Attack
+# frozen_string_literal: true
 
-    ### Configure Cache ###
-  
-    Rack::Attack.cache.store = ActiveSupport::Cache::MemoryStore.new 
-  
-    ### Throttle Spammy Clients ###
-  
-    # Throttle all requests by IP (60rpm)
-    
-    # Max 5 requests per minut
-    throttle('req/ip', limit: 5, period: 1.minute) do |req|
-      req.ip 
-    end
+module Rack
+  # Mitigates abusive requests
+  class Attack
+    Rack::Attack.cache.store = ActiveSupport::Cache::MemoryStore.new
 
-    # Max 100 requests per day
+    # Requests from localhost will be allowed despite matching any number of blocklists or throttles
+    Rack::Attack.safelist_ip('127.0.0.1')
+
+    # Throttle all requests to any route by IP (50rpm/IP)
+    throttle('req/ip', limit: 50, period: 1.minute, &:ip)
+
+    # Throttle requests by Authorization header. 100 requests/day per client
     throttle('api/v1/ip', limit: 100, period: 1.day) do |req|
-        req.ip 
+      req.env['HTTP_AUTHORIZATION'].presence
     end
 
-  
-    # Throttle POST requests to /api/v1/posts by IP address
-    throttle('api/v1/posts/ip', limit: 1, period: 1.minute) do |req|
-        if req.path == '/api/v1/posts' && req.post?
-            req.ip
-        end
+    # Throttle POST requests by Authorization header
+    # Maximum 5 POST requests every minute on any POST route
+    throttle('api/v1/posts/ip', limit: 5, period: 1.minute) do |req|
+      req.env['HTTP_AUTHORIZATION'] if req.env['HTTP_AUTHORIZATION'].presence && req.post?
     end
+
+    # Ban IP for 3 hours if clients makes more than 10 unauthorized requests in 5 minutes
+    Rack::Attack.blocklist('block too many unauthorized requests') do |req|
+      Rack::Attack::Allow2Ban.filter(req.ip, maxretry: 10, findtime: 5.minutes, bantime: 3.hours) do
+        !req.env['HTTP_AUTHORIZATION'].presence
+      end
+    end
+  end
 end


### PR DESCRIPTION
**Changes made:**

- Force SSL(TLS) on production environment;
- Throttle requests by Authorization header and by IP;
- Ban IP when client makes too many unauthorized requests.

Rules: 

1. Every client can make 100 requests a day (any kind of request)
2. Maximum 50 requests/minute per IP
3. Maximum 5 POST requests in 5 minutes per client