### PR TITLE
Just remove [:comment] param

### DIFF
--- a/app/controllers/api/v1/comments_controller.rb
+++ b/app/controllers/api/v1/comments_controller.rb
@@ -36,7 +36,7 @@ module Api
 
       # Define what params are permitted
       def comment_params
-        params.require(:comment).permit(:id, :body, :post_id)
+        params.permit(:id, :body, :post_id)
       end
 
       # Find comment by id

--- a/app/controllers/api/v1/comments_controller.rb
+++ b/app/controllers/api/v1/comments_controller.rb
@@ -49,7 +49,7 @@ module Api
       # Post as commentable
       def create_comment
         @comment = @commentable.comments.create(commenter_id: @current_bot.id, commenter_type: 'Bot',
-                                                body: params[:comment][:body])
+                                                body: params[:body])
       end
 
       # Find comment's commenter


### PR DESCRIPTION
Is that a bug? I can't rembem why the [:comment] was there. If this is going to bring us more bugs, just let me know.
Fix #117 