### PR TITLE
disable RackAttack middleware in test and development environments

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -28,8 +28,7 @@ Rails.application.configure do
     }
   else
     config.action_controller.perform_caching = false
-
-    config.cache_store = :null_store
+    config.cache_store = :redis_cache_store, { url: ENV.fetch('REDIS_URL_CACHING', 'redis://redis:6379/0') }
   end
 
   # Store uploaded files on the local file system (see config/storage.yml for options).

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -1,4 +1,6 @@
-require "active_support/core_ext/integer/time"
+# frozen_string_literal: true
+
+require 'active_support/core_ext/integer/time'
 
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
@@ -13,6 +15,9 @@ Rails.application.configure do
 
   # Show full error reports.
   config.consider_all_requests_local = true
+
+  # Disable Rack Attack Middleware for development environment
+  Rack::Attack.enabled = false
 
   # Enable/disable caching. By default caching is disabled.
   # Run rails dev:cache to toggle caching.
@@ -49,7 +54,6 @@ Rails.application.configure do
 
   # Highlight code that triggered database queries in logs.
   config.active_record.verbose_query_logs = true
-
 
   # Raises error for missing translations.
   # config.i18n.raise_on_missing_translations = true

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,4 +1,6 @@
-require "active_support/core_ext/integer/time"
+# frozen_string_literal: true
+
+require 'active_support/core_ext/integer/time'
 
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
@@ -33,6 +35,9 @@ Rails.application.configure do
   # Store uploaded files on the local file system (see config/storage.yml for options).
   config.active_storage.service = :local
 
+  # Enable Rack Attack middleware
+  Rack::Attack.enabled = true
+
   # Mount Action Cable outside main process or domain.
   # config.action_cable.mount_path = nil
   # config.action_cable.url = 'wss://example.com/cable'
@@ -46,7 +51,7 @@ Rails.application.configure do
   config.log_level = :info
 
   # Prepend all log lines with the following tags.
-  config.log_tags = [ :request_id ]
+  config.log_tags = [:request_id]
 
   # Use a different cache store in production.
   config.cache_store = :redis_cache_store, { url: ENV.fetch('REDIS_URL_CACHING', 'redis://redis:6379/0') }

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -16,6 +16,9 @@ Rails.application.configure do
   # preloads Rails for running tests, you may have to set it to true.
   config.eager_load = false
 
+  # Disable Rack Attack Middleware for test environment
+  Rack::Attack.enabled = false
+
   # Configure public file server for tests with Cache-Control for performance.
   config.public_file_server.enabled = true
   config.public_file_server.headers = {

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -3,11 +3,6 @@
 module Rack
   # Mitigates abusive requests
   class Attack
-    Rack::Attack.cache.store = ActiveSupport::Cache::MemoryStore.new
-
-    # Requests from localhost will be allowed despite matching any number of blocklists or throttles
-    Rack::Attack.safelist_ip('127.0.0.1')
-
     # Throttle all requests to any route by IP (50rpm/IP)
     throttle('req/ip', limit: 50, period: 1.minute, &:ip)
 
@@ -16,15 +11,9 @@ module Rack
       req.env['HTTP_AUTHORIZATION'].presence
     end
 
-    # Throttle POST requests by Authorization header
-    # Maximum 5 POST requests every minute on any POST route
-    throttle('api/v1/posts/ip', limit: 5, period: 1.minute) do |req|
-      req.env['HTTP_AUTHORIZATION'] if req.env['HTTP_AUTHORIZATION'].presence && req.post?
-    end
-
     # Ban IP for 3 hours if clients makes more than 10 unauthorized requests in 5 minutes
     Rack::Attack.blocklist('block too many unauthorized requests') do |req|
-      Rack::Attack::Allow2Ban.filter(req.ip, maxretry: 10, findtime: 5.minutes, bantime: 3.hours) do
+      Rack::Attack::Allow2Ban.filter(req.ip, maxretry: 50, findtime: 5.minutes, bantime: 3.hours) do
         !req.env['HTTP_AUTHORIZATION'].presence
       end
     end


### PR DESCRIPTION
Besides disabling it for the mentioned environments, I also removed the RackAttack cache line so it's now using Rail's default cache which is Redis and removed the limit of 5 posts requests per minute (no longer need because images are now processed asynchronously).